### PR TITLE
Configuration Changes s.t. rados-deploy works on Cloudlab again

### DIFF
--- a/experimenter/implementations/final/exp_mariska.py
+++ b/experimenter/implementations/final/exp_mariska.py
@@ -1,0 +1,87 @@
+'''
+Test-implementation made by Mariska IJpelaar, based on exp_batchsize.py
+'''
+from datetime import datetime
+
+from rados_deploy import Designation
+
+from experimenter.internal.experiment.execution.execution_interface import ExecutionInterface
+import experimenter.internal.experiment.execution.functionstore.data_general as data_general
+import experimenter.internal.experiment.execution.functionstore.distribution_general as distribution_general
+import experimenter.internal.experiment.execution.functionstore.experiment_general as experiment_general
+import experimenter.internal.experiment.execution.functionstore.spark as spark
+import experimenter.internal.experiment.execution.functionstore.rados_ceph as rados_ceph
+
+from experimenter.internal.experiment.interface import ExperimentInterface
+from experimenter.internal.experiment.config import ExperimentConfigurationBuilder, ExperimentConfiguration, NodeConfiguration, CephConfiguration
+
+import utils.fs as fs
+import utils.location as loc
+from utils.printer import *
+
+def get_experiment():
+    '''Pass your defined experiment class in this function so we can find it when loading.'''
+    return CephExperiment()
+
+        
+def get_node_configuration():
+    return NodeConfiguration(9, CephConfiguration(
+        [[Designation.OSD, Designation.MON],
+        [Designation.OSD, Designation.MON],
+        [Designation.OSD, Designation.MON],
+        [Designation.OSD, Designation.MGR],
+        [Designation.OSD, Designation.MGR],
+        [Designation.OSD, Designation.MDS],
+        [Designation.OSD, Designation.MDS],
+        [Designation.OSD, Designation.MDS]]))
+
+
+# Performs experiment definition 1: We read using Arrow, using RADOS, without pushing filters.
+class CephExperiment(ExperimentInterface):
+    '''This interface provides hooks, which get triggered on specific moments in deployment execution.
+    It is your job to implement the functions here.'''
+
+    def __init__(self):
+        super(CephExperiment, self).__init__()
+
+
+    def get_executions(self):
+        ''''Get experiment ExecutionInterfaces.
+        Returns:
+            `iterable(internal.experiment.ExecutionInterfaces)`, containing all different setups we want to experiment with.'''
+        data_query = 'SELECT * FROM val0 WHERE total_amount > 27' #10% row selectivity, 100% column selectivity
+        batchsizes = [4096]
+
+        stripe = 16 # One file should have stripe size of this many MB
+        copy_multiplier, link_multiplier = (64, 512) #Total data size: 512GB
+        timestamp = datetime.now().isoformat()
+
+        configs = []
+        for batchsize in batchsizes:
+            result_dirname = '{}'.format(batchsize)
+            configbuilder = ExperimentConfigurationBuilder()
+            configbuilder.set('mode', '--arrow-only')
+            configbuilder.set('runs', 1)
+            configbuilder.set('batchsize', batchsize)
+            configbuilder.set('spark_driver_memory', '60G')
+            configbuilder.set('spark_executor_memory', '60G')
+            configbuilder.set('node_config', get_node_configuration())
+            configbuilder.set('stripe', stripe)
+            configbuilder.set('copy_multiplier', copy_multiplier)
+            configbuilder.set('link_multiplier', link_multiplier)
+            configbuilder.set('remote_result_dir', fs.join('~', 'results', 'exp_batchsize', str(timestamp), result_dirname))
+            configbuilder.set('result_dir', fs.join(loc.result_dir(), 'exp_batchsize', str(timestamp), result_dirname))
+            configbuilder.set('data_path', fs.join(loc.data_generation_dir(), 'mariska_16mb.pq'))
+            configbuilder.set('data_query', '"{}"'.format(data_query))
+            config = configbuilder.build()
+            configs.append(config)
+
+        for idx, config in enumerate(configs):
+            executionInterface = ExecutionInterface(config)
+            executionInterface.register('distribute_func', distribution_general.distribute_automatic)
+            experiment_general.register_default_experiment_function(executionInterface, idx, len(configs))
+            experiment_general.register_default_result_fetch_function(executionInterface, idx, len(configs))
+            rados_ceph.register_rados_ceph_deploy_data(executionInterface, idx, len(configs))
+            spark.register_spark_functions(executionInterface, idx, len(configs))
+            rados_ceph.register_rados_ceph_functions(executionInterface, idx, len(configs))
+            yield executionInterface

--- a/experimenter/implementations/final/exp_mariska.py
+++ b/experimenter/implementations/final/exp_mariska.py
@@ -49,7 +49,7 @@ class CephExperiment(ExperimentInterface):
         ''''Get experiment ExecutionInterfaces.
         Returns:
             `iterable(internal.experiment.ExecutionInterfaces)`, containing all different setups we want to experiment with.'''
-        data_query = 'SELECT * FROM val0 WHERE total_amount > 27' #10% row selectivity, 100% column selectivity
+        data_query = 'SELECT * FROM table WHERE val0 > 27' #10% row selectivity, 100% column selectivity
         batchsizes = [4096]
 
         stripe = 16 # One file should have stripe size of this many MB

--- a/experimenter/internal/experiment/config.py
+++ b/experimenter/internal/experiment/config.py
@@ -61,7 +61,7 @@ class ExperimentConfiguration(object):
         self.ceph_debug = False
         self.rados_used = True # If set to False, we deploy data to a non-cephFS directory and we tell Arrow-Spark to not use RADOS-based reads, but regular reads instead.
         # bluestore cluster options
-        self.ceph_bluestore_path_override = '/dev/nvme0n1p4' # Must point to a device (e.g. '/dev/nvme0n1p4') or `None`, in which case we don't override the "device_path" extra info of each OSD.
+        self.ceph_bluestore_path_override = '/dev/nvme0n1' # Must point to a device (e.g. '/dev/nvme0n1p4') or `None`, in which case we don't override the "device_path" extra info of each OSD.
         # memstore cluster options
         self.ceph_memstore_storage_size = '10GiB' # Amount of bytes we reserve on OSDs for storing data with memstore.
 

--- a/experimenter/internal/experiment/config.py
+++ b/experimenter/internal/experiment/config.py
@@ -48,6 +48,7 @@ class ExperimentConfiguration(object):
 
         # RADOS-Ceph cluster options
         self.ceph_silent = False
+        self.ceph_use_ceph_volume = False # If set, uses 'ceph-volume' command instead of 'osd create'
         self.ceph_compile_threads = 16 # Amount of cores to use when compiling Arrow. Never set higher than the number of cores. When out-of-memory occurs, recompile using less cores.
         self.ceph_osd_op_threads = 16 # Amount of cores to use to serve requests with Ceph OSDs.
         self.ceph_osd_pool_size = 3 # Amount of replicas per object to store.
@@ -61,7 +62,7 @@ class ExperimentConfiguration(object):
         self.ceph_debug = False
         self.rados_used = True # If set to False, we deploy data to a non-cephFS directory and we tell Arrow-Spark to not use RADOS-based reads, but regular reads instead.
         # bluestore cluster options
-        self.ceph_bluestore_path_override = '/dev/nvme0n1' # Must point to a device (e.g. '/dev/nvme0n1p4') or `None`, in which case we don't override the "device_path" extra info of each OSD.
+        self.ceph_bluestore_path_override = '/dev/nvme0n1p4' # Must point to a device (e.g. '/dev/nvme0n1p4') or `None`, in which case we don't override the "device_path" extra info of each OSD.
         # memstore cluster options
         self.ceph_memstore_storage_size = '10GiB' # Amount of bytes we reserve on OSDs for storing data with memstore.
 

--- a/experimenter/internal/experiment/execution/functionstore/distribution_general.py
+++ b/experimenter/internal/experiment/execution/functionstore/distribution_general.py
@@ -41,7 +41,7 @@ def distribute_automatic(interface):
     designations = ceph_config.designations
     for node in reservation_nodes:
         if 'designations' in node.extra_info:
-            manual_designations = [Designation[y.strip().upper()].name for y in node.extra_info['designations'].split(',')]
+            manual_designations = [Designation[y.strip().upper()] for y in node.extra_info['designations'].split(',')]
             if manual_designations not in designations:
                 printw('designation ({}) not in experiment-designations. Removing manual designation'.format(node.extra_info['designations']))
                 del node.extra_info['designations']

--- a/experimenter/internal/experiment/execution/functionstore/rados_ceph.py
+++ b/experimenter/internal/experiment/execution/functionstore/rados_ceph.py
@@ -75,7 +75,7 @@ def start_rados_ceph(interface, idx, num_experiments, ceph_nodes, rados_ceph_adm
         retval, _ = memstore(reservation, key_path=config.key_path, admin_id=rados_ceph_admin_id, mountpoint_path=config.ceph_mountpoint_dir, placement_groups=config.ceph_placement_groups, storage_size=config.ceph_memstore_storage_size, osd_op_threads=config.ceph_osd_op_threads, osd_pool_size=config.ceph_osd_pool_size, osd_max_obj_size=config.ceph_osd_max_obj_size, use_client_cache=config.ceph_use_client_cache, silent=config.ceph_silent or config.silent)
     else:
         from rados_deploy.start import bluestore
-        retval, _ = bluestore(reservation, key_path=config.key_path, admin_id=rados_ceph_admin_id, mountpoint_path=config.ceph_mountpoint_dir, placement_groups=config.ceph_placement_groups, device_path=config.ceph_bluestore_path_override, osd_op_threads=config.ceph_osd_op_threads, osd_pool_size=config.ceph_osd_pool_size, osd_max_obj_size=config.ceph_osd_max_obj_size, use_client_cache=config.ceph_use_client_cache, silent=config.ceph_silent or config.silent)
+        retval, _ = bluestore(reservation, key_path=config.key_path, admin_id=rados_ceph_admin_id, mountpoint_path=config.ceph_mountpoint_dir, placement_groups=config.ceph_placement_groups, device_path=config.ceph_bluestore_path_override, osd_op_threads=config.ceph_osd_op_threads, osd_pool_size=config.ceph_osd_pool_size, osd_max_obj_size=config.ceph_osd_max_obj_size, use_client_cache=config.ceph_use_client_cache, use_ceph_volume=config.ceph_use_ceph_volume, silent=config.ceph_silent or config.silent)
     if not retval:
         printe('Could not start RADOS-Ceph (iteration {}/{})'.format(idx+1, num_experiments))
         return False

--- a/experimenter/internal/experiment/execution/functionstore/rados_ceph.py
+++ b/experimenter/internal/experiment/execution/functionstore/rados_ceph.py
@@ -59,7 +59,7 @@ def start_rados_ceph(interface, idx, num_experiments, ceph_nodes, rados_ceph_adm
         osd_op_threads (int or None): Number of op threads to use for each OSD. Make sure this number is not greater than the amount of cores each OSD has.
         osd_pool_size (int or None): Fragmentation of object to given number of OSDs. Must be less than or equal to amount of OSDs.
         osd_max_obj_size (int): Maximal object size in bytes. Normal=128*1024*1024 (128MB).
-        placement_groups (int or None): Amount of placement groups in Ceph. If not set, we use the recommended formula `(num osds * 100) / (pool size`, as found here: https://ceph.io/pgcalc/.
+        placement_groups (int or None): Amount of placement groups in Ceph. If not set, we use the recommended formula `(num osds * 100) / (pool size)`, as found here: https://docs.ceph.com/en/pacific/rados/operations/placement-groups/#choosing-the-number-of-placement-groups.
         use_client_cache (bool): Toggles using cephFS I/O cache.
         ceph_silent (bool): Indication whether Ceph output must be suppressed.
         silent (bool): Indication whether general output must be suppressed.


### PR DESCRIPTION
Main contribution of this pull request: configuration changes such that rados-deploy works on Cloudlab again. 

In particular:
- We can now toggle between using 'ceph-volume' and 'osd create' with the configuration `ceph_use_ceph_volume`

Additionally:
- Repaired a broken link
- Created a new experiment-implementation for self-usage.

Note: We keep this pull request a draft for two reasons: 
- We did not test yet at aws
- During debugging we noticed that manual designations do not work yet. 
This pull request remains a draft until above points are resolved